### PR TITLE
feat: agregar navegación desde Materias a MateriaDetalle y crear vista detallada

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+// src/App.tsx
+
 import { Redirect, Route } from 'react-router-dom';
 import {
   IonApp,
@@ -10,11 +12,12 @@ import {
   setupIonicReact
 } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
-import { cogOutline, documentText, ellipse, list, logoAlipay, personCircle, personCircleOutline, square, triangle } from 'ionicons/icons';
+import { cogOutline, documentText, list, personCircle } from 'ionicons/icons';
 import Perfil from './pages/Perfil';
 import Materias from './pages/Materias';
 import Otros from './pages/Otros';
 import Opciones from './pages/Opciones';
+import MateriaDetalle from './pages/MateriaDetalle';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -32,13 +35,7 @@ import '@ionic/react/css/text-transformation.css';
 import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
-/**
- * Ionic Dark Mode
- * -----------------------------------------------------
- * For more info, please see:
- * https://ionicframework.com/docs/theming/dark-mode
- */
-
+/* Ionic Dark Mode */
 /* import '@ionic/react/css/palettes/dark.always.css'; */
 /* import '@ionic/react/css/palettes/dark.class.css'; */
 import '@ionic/react/css/palettes/dark.system.css';
@@ -57,21 +54,12 @@ const App: React.FC = () => (
           <Route exact path="/">
             <Redirect to="/login" />
           </Route>
-          <Route path='/login'>
-            <Login/>
-          </Route>
-          <Route exact path="/perfil">
-            <Perfil />
-          </Route>
-          <Route exact path="/materias">
-            <Materias />
-          </Route>
-          <Route path="/otros">
-            <Otros />
-          </Route>
-          <Route path="/opciones">
-            <Opciones />
-          </Route>
+          <Route path='/login' component={Login} exact />
+          <Route path="/perfil" component={Perfil} exact />
+          <Route path="/materias" component={Materias} exact />
+          <Route path="/materia/:nombre" component={MateriaDetalle} exact />
+          <Route path="/otros" component={Otros} exact />
+          <Route path="/opciones" component={Opciones} exact />
         </IonRouterOutlet>
         <IonTabBar slot="bottom">
           <IonTabButton tab="perfil" href="/perfil">

--- a/src/components/MateriaCard.css
+++ b/src/components/MateriaCard.css
@@ -1,0 +1,10 @@
+
+
+.materia-detail-button {
+    position: absolute;
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+  }
+  
+  

--- a/src/components/MateriaCard.tsx
+++ b/src/components/MateriaCard.tsx
@@ -1,0 +1,28 @@
+// src/components/MateriaCard.tsx
+
+import React from 'react';
+import { IonCard, IonCardContent, IonCardHeader, IonCardTitle } from '@ionic/react';
+import './MateriaCard.css';
+
+interface MateriaCardProps {
+  nombre: string;
+  profesor: string;
+  semestre: string;
+  onClick: () => void;
+}
+
+const MateriaCard: React.FC<MateriaCardProps> = ({ nombre, profesor, semestre, onClick }) => {
+  return (
+    <IonCard button onClick={onClick} className="materia-card">
+      <IonCardHeader>
+        <IonCardTitle>{nombre}</IonCardTitle>
+      </IonCardHeader>
+      <IonCardContent>
+        <p>Profesor: {profesor}</p>
+        <p>Semestre: {semestre}</p>
+      </IonCardContent>
+    </IonCard>
+  );
+};
+
+export default MateriaCard;

--- a/src/components/MateriaCard.tsx
+++ b/src/components/MateriaCard.tsx
@@ -1,7 +1,7 @@
 // src/components/MateriaCard.tsx
 
 import React from 'react';
-import { IonCard, IonCardContent, IonCardHeader, IonCardTitle } from '@ionic/react';
+import { IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonItem, IonLabel } from '@ionic/react';
 import './MateriaCard.css';
 
 interface MateriaCardProps {
@@ -17,10 +17,18 @@ const MateriaCard: React.FC<MateriaCardProps> = ({ nombre, profesor, semestre, o
       <IonCardHeader>
         <IonCardTitle>{nombre}</IonCardTitle>
       </IonCardHeader>
-      <IonCardContent>
-        <p>Profesor: {profesor}</p>
-        <p>Semestre: {semestre}</p>
-      </IonCardContent>
+        <IonCardContent>
+          <IonItem button detail={true}>
+            <IonLabel>
+              <h4>Profesor/a:</h4>
+              <p>{profesor}</p>
+            </IonLabel>
+            <IonLabel>
+              <h4>Semestre</h4>
+              <p>{semestre}</p>
+            </IonLabel>
+          </IonItem>
+        </IonCardContent>
     </IonCard>
   );
 };

--- a/src/pages/MateriaDetalle.css
+++ b/src/pages/MateriaDetalle.css
@@ -1,0 +1,23 @@
+/* src/pages/MateriaDetalle.css */
+
+.table-responsive {
+    overflow-x: auto;
+  }
+  
+  .materia-detalle-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+  }
+  
+  .materia-detalle-table th, .materia-detalle-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: center;
+  }
+  
+  .materia-detalle-table th {
+    background-color: #f2f2f2;
+    color: black;
+  }
+  

--- a/src/pages/MateriaDetalle.tsx
+++ b/src/pages/MateriaDetalle.tsx
@@ -1,7 +1,7 @@
 // src/pages/MateriaDetalle.tsx
 
 import React from 'react';
-import { IonBackButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import { IonBackButton, IonButtons, IonCard, IonCardContent, IonCardHeader, IonCardTitle, IonCol, IonContent, IonFab, IonFabButton, IonGrid, IonHeader, IonIcon, IonItem, IonLabel, IonPage, IonRow, IonTitle, IonToolbar } from '@ionic/react';
 import './MateriaDetalle.css';
 import { calculatorOutline } from 'ionicons/icons';
 
@@ -28,32 +28,60 @@ const MateriaDetalle: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent className="ion-padding">
-        <div className="table-responsive">
-          <table className="materia-detalle-table">
-            <thead>
-              <tr>
-                <th>Inscripción (fecha)</th>
-                <th>Asistencia</th>
-                <th>1ra Parcial</th>
-                <th>2da Parcial</th>
-                <th>Trab. Pract.</th>
-                <th>Trab. Lab.</th>
-                <th>Eval.</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{datos.inscripcion}</td>
-                <td>{datos.asistencia}</td>
-                <td>{datos.parcial1}</td>
-                <td>{datos.parcial2}</td>
-                <td>{datos.trabPract}</td>
-                <td>{datos.trabLab}</td>
-                <td>{datos.eval}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <IonCard>
+          <IonCardHeader>
+            <IonCardTitle>Con Respecto a la Materia</IonCardTitle>
+          </IonCardHeader>
+          <IonCardContent>
+            <IonItem>
+              <IonLabel>
+                <h3>F. Inscripción</h3>
+                <p>{datos.inscripcion}</p>
+              </IonLabel>
+              <IonLabel>
+                <h3>Asistencia</h3>
+                <p>{datos.asistencia}</p>
+              </IonLabel>
+            </IonItem>
+          </IonCardContent>
+        </IonCard>
+        <IonCard>
+          <IonCardHeader>
+            <IonCardTitle>Desempeño</IonCardTitle>
+          </IonCardHeader>
+          <IonCardContent>
+            <IonItem>
+              <IonGrid>
+                <IonRow>
+                  <IonCol sizeXs='6' sizeSm='4' sizeMd='3'>
+                    <IonLabel>
+                      <h3>1ra Parcial</h3>
+                      <p>{datos.parcial1}</p>
+                    </IonLabel>
+                  </IonCol>
+                  <IonCol sizeXs='6' sizeSm='4' sizeMd='3'>
+                    <IonLabel>
+                      <h3>2da Parcial</h3>
+                      <p>{datos.parcial2}</p>
+                    </IonLabel>
+                  </IonCol>
+                  <IonCol sizeXs='6' sizeSm='4' sizeMd='3'>
+                    <IonLabel>
+                      <h3>Trabajo Practico</h3>
+                      <p>{datos.trabPract}</p>
+                    </IonLabel>
+                  </IonCol>
+                  <IonCol sizeXs='6' sizeSm='4' sizeMd='3'>
+                    <IonLabel>
+                      <h3>Trabajo Laboratorio</h3>
+                      <p>{datos.trabLab}</p>
+                    </IonLabel>
+                  </IonCol>
+                </IonRow>
+              </IonGrid>
+            </IonItem>
+          </IonCardContent>
+        </IonCard>
         <IonFab vertical="bottom" horizontal="end" slot="fixed">
           <IonFabButton >
             <IonIcon icon={calculatorOutline} />

--- a/src/pages/MateriaDetalle.tsx
+++ b/src/pages/MateriaDetalle.tsx
@@ -1,0 +1,67 @@
+// src/pages/MateriaDetalle.tsx
+
+import React from 'react';
+import { IonBackButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import './MateriaDetalle.css';
+import { calculatorOutline } from 'ionicons/icons';
+
+const MateriaDetalle: React.FC = () => {
+  const datos = {
+    inscripcion: '01/02/2024',
+    asistencia: '90%',
+    parcial1: '80',
+    parcial2: '85',
+    trabPract: '88',
+    trabLab: '92',
+    eval: '86',
+  };
+
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/materias" />
+          </IonButtons>
+          <IonTitle>Detalle de Materia</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <div className="table-responsive">
+          <table className="materia-detalle-table">
+            <thead>
+              <tr>
+                <th>Inscripción (fecha)</th>
+                <th>Asistencia</th>
+                <th>1ra Parcial</th>
+                <th>2da Parcial</th>
+                <th>Trab. Pract.</th>
+                <th>Trab. Lab.</th>
+                <th>Eval.</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{datos.inscripcion}</td>
+                <td>{datos.asistencia}</td>
+                <td>{datos.parcial1}</td>
+                <td>{datos.parcial2}</td>
+                <td>{datos.trabPract}</td>
+                <td>{datos.trabLab}</td>
+                <td>{datos.eval}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <IonFab vertical="bottom" horizontal="end" slot="fixed">
+          <IonFabButton >
+            <IonIcon icon={calculatorOutline} />
+          </IonFabButton>
+        </IonFab>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default MateriaDetalle;

--- a/src/pages/Materias.css
+++ b/src/pages/Materias.css
@@ -1,0 +1,4 @@
+IonCard {
+    margin-bottom: 20px;
+  }
+  

--- a/src/pages/Materias.tsx
+++ b/src/pages/Materias.tsx
@@ -1,7 +1,7 @@
 // src/pages/Materias.tsx 
 
 import React from 'react';
-import { IonAccordionGroup, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import { IonAccordionGroup, IonCol, IonContent, IonFab, IonFabButton, IonGrid, IonHeader, IonIcon, IonPage, IonRow, IonTitle, IonToolbar } from '@ionic/react';
 import { calculatorOutline } from 'ionicons/icons';
 import { useHistory } from 'react-router-dom';
 import MateriaCard from '../components/MateriaCard';
@@ -14,6 +14,9 @@ const Materias: React.FC = () => {
     { nombre: 'Matemáticas', profesor: 'Juan Pérez', semestre: '1er Semestre' },
     { nombre: 'Física', profesor: 'Ana Gómez', semestre: '2do Semestre' },
     { nombre: 'Química', profesor: 'María López', semestre: '3er Semestre' },
+    { nombre: 'Nombre de Materia que sea extenso relato', profesor: 'Juan Pérez', semestre: '1er Semestre' },
+    { nombre: 'Física', profesor: 'Ana Gómez', semestre: '2do Semestre' },
+    { nombre: 'Química', profesor: 'Nombre de profesor que tambien sea extenso', semestre: '3er Semestre' }
   ];
 
   const handleMateriaClick = (nombre: string) => {
@@ -33,17 +36,21 @@ const Materias: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent fullscreen={true} className='ion-padding'>
-        <IonAccordionGroup expand='compact'>
-          {materias.map((materia, index) => (
-            <MateriaCard
-              key={index}
-              nombre={materia.nombre}
-              profesor={materia.profesor}
-              semestre={materia.semestre}
-              onClick={() => handleMateriaClick(materia.nombre)}
-            />
-          ))}
-        </IonAccordionGroup>
+        <IonGrid>
+          <IonRow>
+            {materias.map((materia, index) => (
+                <IonCol  sizeXs='12' sizeSm='6'  sizeLg='4'  sizeMd='4'  sizeXl='3'>
+                  <MateriaCard
+                    key={index}
+                    nombre={materia.nombre}
+                    profesor={materia.profesor}
+                    semestre={materia.semestre}
+                    onClick={() => handleMateriaClick(materia.nombre)}
+                  />
+                </IonCol>
+            ))}
+          </IonRow>
+        </IonGrid>
         <IonFab vertical="bottom" horizontal="end" slot="fixed">
           <IonFabButton>
             <IonIcon icon={calculatorOutline} />

--- a/src/pages/Materias.tsx
+++ b/src/pages/Materias.tsx
@@ -39,9 +39,8 @@ const Materias: React.FC = () => {
         <IonGrid>
           <IonRow>
             {materias.map((materia, index) => (
-                <IonCol  sizeXs='12' sizeSm='6'  sizeLg='4'  sizeMd='4'  sizeXl='3'>
+                <IonCol key={index} sizeXs='12' sizeSm='6'  sizeLg='4'  sizeMd='4'  sizeXl='3'>
                   <MateriaCard
-                    key={index}
                     nombre={materia.nombre}
                     profesor={materia.profesor}
                     semestre={materia.semestre}

--- a/src/pages/Materias.tsx
+++ b/src/pages/Materias.tsx
@@ -1,8 +1,30 @@
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
-import ExploreContainer from '../components/ExploreContainer';
+// src/pages/Materias.tsx 
+
+import React from 'react';
+import { IonAccordionGroup, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import { calculatorOutline } from 'ionicons/icons';
+import { useHistory } from 'react-router-dom';
+import MateriaCard from '../components/MateriaCard';
 import './Materias.css';
 
 const Materias: React.FC = () => {
+  const history = useHistory();
+  
+  const materias = [
+    { nombre: 'Matemáticas', profesor: 'Juan Pérez', semestre: '1er Semestre' },
+    { nombre: 'Física', profesor: 'Ana Gómez', semestre: '2do Semestre' },
+    { nombre: 'Química', profesor: 'María López', semestre: '3er Semestre' },
+  ];
+
+  const handleMateriaClick = (nombre: string) => {
+    history.push(`/materia/${nombre}`);
+  };
+
+  const handleCalculatorClick = () => {
+    // Lógica para manejar el click del botón de la calculadora
+    console.log('Calculator button clicked');
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -10,13 +32,23 @@ const Materias: React.FC = () => {
           <IonTitle>Materias</IonTitle>
         </IonToolbar>
       </IonHeader>
-      <IonContent fullscreen>
-        <IonHeader collapse="condense">
-          <IonToolbar>
-            <IonTitle size="large">Materias</IonTitle>
-          </IonToolbar>
-        </IonHeader>
-        <ExploreContainer name="Aquí información de las materias" />
+      <IonContent fullscreen={true} className='ion-padding'>
+        <IonAccordionGroup expand='compact'>
+          {materias.map((materia, index) => (
+            <MateriaCard
+              key={index}
+              nombre={materia.nombre}
+              profesor={materia.profesor}
+              semestre={materia.semestre}
+              onClick={() => handleMateriaClick(materia.nombre)}
+            />
+          ))}
+        </IonAccordionGroup>
+        <IonFab vertical="bottom" horizontal="end" slot="fixed">
+          <IonFabButton>
+            <IonIcon icon={calculatorOutline} />
+          </IonFabButton>
+        </IonFab>
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
- Implementada la navegación desde la lista de Materias a MateriaDetalle al hacer clic en una materia.
- Añadido botón de acción flotante con icono de calculadora en la vista de Materias.
- Creada la vista de MateriaDetalle con una tabla responsiva que muestra información específica de la materia.
- Añadido botón de retroceso con un icono en el encabezado de MateriaDetalle para facilitar la navegación.